### PR TITLE
Fix Sequence::slice item handling

### DIFF
--- a/src/Sequence.php
+++ b/src/Sequence.php
@@ -423,8 +423,8 @@ class Sequence implements ArrayAccess, Countable, IteratorAggregate
      */
     public function slice(int $offset, ?int $length): Sequence
     {
-        // Initialize the result.
-        $slice = new Sequence($this->types);
+        // Initialize the result, preserving the original default value.
+        $slice = new Sequence($this->types, $this->defaultValue);
 
         // Check for zero-length slice.
         if ($length === 0) {
@@ -433,7 +433,7 @@ class Sequence implements ArrayAccess, Countable, IteratorAggregate
 
         // Construct the result.
         $items = array_slice($this->items, $offset, $length);
-        $slice->append($items);
+        $slice->append(...$items);
         return $slice;
     }
 


### PR DESCRIPTION
## Summary
- preserve original default value when slicing a Sequence
- append sliced values individually to avoid type errors

## Testing
- `php -l src/Sequence.php`
- `php /tmp/test_slice.php`
- `php /tmp/test_default.php`


------
https://chatgpt.com/codex/tasks/task_e_68968e61c69483278b0bd7f48361d9b3